### PR TITLE
feat(theme): add dark mode toggle and theme support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/wagtail_app/__pycache__
+    /wagtail_app/__pycache__
 /wagtail_app/home/__pycache__
 /wagtail_app/blog/__pycache__
 __pycache__

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1,0 +1,41 @@
+/* Dark mode styles */
+:root {
+    --bg-color: #ffffff;
+    --text-color: #333333;
+    --bg-dark: #f8f9fa;
+    --border-color: #dee2e6;
+}
+
+[data-theme="dark"] {
+    --bg-color: #1a1a1a;
+    --text-color: #ffffff;
+    --bg-dark: #2d2d2d;
+    --border-color: #404040;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    transition: background-color 0.3s, color 0.3s;
+}
+
+/* Dark mode toggle button */
+.dark-mode-toggle {
+    background: none;
+    border: none;
+    color: var(--text-color);
+    cursor: pointer;
+    padding: 5px;
+    font-size: 1.2rem;
+}
+
+/* Add dark mode styles for other elements */
+[data-theme="dark"] .card,
+[data-theme="dark"] .navbar,
+[data-theme="dark"] .footer {
+    background-color: var(--bg-dark);
+}
+
+[data-theme="dark"] .border {
+    border-color: var(--border-color) !important;
+}

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,271 @@
+:root {
+    /* Existing variables */
+    --bg-primary: #ffffff;
+    --bg-secondary: #f8f9fa;
+    --text-primary: #333333;
+    --text-secondary: #666666;
+    --border-color: #dee2e6;
+    --accent-color: #007bff;
+    
+    /* Additional variables for better coverage */
+    --header-bg: #ffffff;
+    --blog-title-color: #333333;
+    --blog-text-color: #666666;
+    --card-shadow: rgba(0, 0, 0, 0.1);
+    --link-color: #007bff;
+    --link-hover-color: #0056b3;
+    --code-bg: #f8f9fa;
+    --blockquote-bg: #f8f9fa;
+    --blockquote-border: #dee2e6;
+}
+
+[data-theme="dark"] {
+    /* Existing dark mode variables */
+    --bg-primary: #1a1a1a;
+    --bg-secondary: #2d2d2d;
+    --text-primary: #ffffff;
+    --text-secondary: #cccccc;
+    --border-color: #404040;
+    --accent-color: #3498db;
+    
+    /* Additional dark mode variables */
+    --header-bg: #2d2d2d;
+    --blog-title-color: #ffffff;
+    --blog-text-color: #cccccc;
+    --card-shadow: rgba(0, 0, 0, 0.3);
+    --link-color: #3498db;
+    --link-hover-color: #2980b9;
+    --code-bg: #2d2d2d;
+    --blockquote-bg: #2d2d2d;
+    --blockquote-border: #404040;
+}
+
+/* Base styles */
+body {
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    transition: all 0.3s ease;
+}
+
+/* Header styles */
+.site-header {
+    background-color: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+}
+
+/* Navigation */
+.nav-link {
+    color: var(--text-primary);
+}
+
+.nav-link:hover {
+    color: var(--accent-color);
+}
+
+/* Sections */
+.section-padding {
+    background-color: var(--section-bg-light);
+}
+
+.bg-dark {
+    background-color: var(--section-bg-dark) !important;
+    color: var(--text-primary);
+}
+
+/* Cards and content boxes */
+.card, 
+.feature-card,
+.service-card,
+.testimonial,
+.blog-card {
+    background-color: var(--card-bg);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+/* Hero section */
+.hero-section {
+    background-color: var(--hero-bg);
+}
+
+/* Footer */
+.site-footer {
+    background-color: var(--footer-bg);
+    border-top: 1px solid var(--border-color);
+}
+
+.footer-links a {
+    color: var(--text-secondary);
+}
+
+.footer-links a:hover {
+    color: var(--accent-color);
+}
+
+/* Form elements */
+input, textarea, select {
+    background-color: var(--bg-secondary);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+/* Buttons */
+.btn-primary {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+}
+
+.btn-outline-primary {
+    color: var(--accent-color);
+    border-color: var(--accent-color);
+}
+
+.btn-outline-primary:hover {
+    background-color: var(--accent-color);
+    color: #ffffff;
+}
+
+/* Theme toggle button */
+.theme-toggle {
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    cursor: pointer;
+    padding: 8px;
+    font-size: 1.2rem;
+    transition: color 0.3s;
+}
+
+.theme-toggle:hover {
+    color: var(--accent-color);
+}
+
+/* Additional dark mode specific styles */
+[data-theme="dark"] .section-title,
+[data-theme="dark"] .feature-title,
+[data-theme="dark"] .service-title,
+[data-theme="dark"] .testimonial-author-name {
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .section-description,
+[data-theme="dark"] .feature-description,
+[data-theme="dark"] .service-description,
+[data-theme="dark"] .testimonial-text {
+    color: var(--text-secondary);
+}
+
+/* Blog specific variables */
+:root {
+    --blog-card-bg: var(--bg-secondary);
+    --blog-meta-color: var(--text-secondary);
+    --blog-excerpt-color: var(--text-secondary);
+    --widget-bg: var(--bg-secondary);
+    --widget-title-color: var(--text-primary);
+    --widget-text-color: var(--text-secondary);
+    --tag-bg: var(--bg-secondary);
+    --tag-color: var(--text-primary);
+}
+
+[data-theme="dark"] {
+    --blog-card-bg: #2d2d2d;
+    --blog-meta-color: #a0a0a0;
+    --blog-excerpt-color: #cccccc;
+    --widget-bg: #2d2d2d;
+    --widget-title-color: #ffffff;
+    --widget-text-color: #cccccc;
+    --tag-bg: #3d3d3d;
+    --tag-color: #ffffff;
+}
+
+/* Blog specific styles */
+.blog-card {
+    background-color: var(--blog-card-bg);
+    border-color: var(--border-color);
+    transition: all 0.3s ease;
+}
+
+.blog-title a {
+    color: var(--blog-title-color);
+    transition: color 0.3s ease;
+}
+
+.blog-meta {
+    color: var(--blog-meta-color, var(--text-secondary));
+}
+
+.blog-excerpt {
+    color: var(--blog-excerpt-color, var(--text-secondary));
+}
+
+/* Blog sidebar widgets */
+.sidebar-widget {
+    background-color: var(--widget-bg, var(--bg-secondary));
+    border-color: var(--border-color);
+    transition: all 0.3s ease;
+}
+
+.widget-title {
+    color: var(--widget-title-color, var(--text-primary));
+}
+
+.widget-content {
+    color: var(--widget-text-color, var(--text-secondary));
+}
+
+/* Tags */
+.tag {
+    background-color: var(--tag-bg, var(--bg-secondary));
+    color: var(--tag-color, var(--text-primary));
+    transition: all 0.3s ease;
+}
+
+.tag:hover {
+    background-color: var(--accent-color);
+    color: #ffffff;
+}
+
+/* Blog pagination */
+.pagination .page-link {
+    background-color: var(--bg-secondary);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+.pagination .page-link:hover {
+    background-color: var(--accent-color);
+    color: #ffffff;
+}
+
+.pagination .active .page-link {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    color: #ffffff;
+}
+
+/* Blog search widget */
+.search-widget input {
+    background-color: var(--bg-secondary);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+/* Blog post content */
+.blog-post-content {
+    color: var(--text-primary);
+}
+
+.post-meta {
+    color: var(--blog-meta-color, var(--text-secondary));
+}
+
+.post-title {
+    color: var(--blog-title-color);
+}
+
+/* Newsletter widget */
+.newsletter-widget input {
+    background-color: var(--bg-secondary);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}

--- a/static/js/dark-mode.js
+++ b/static/js/dark-mode.js
@@ -1,0 +1,29 @@
+// Dark mode functionality
+document.addEventListener('DOMContentLoaded', () => {
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const icon = darkModeToggle.querySelector('i');
+
+    // Check for saved dark mode preference
+    const darkMode = localStorage.getItem('darkMode') === 'true';
+    
+    // Set initial dark mode state
+    if (darkMode) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        icon.classList.replace('fa-moon', 'fa-sun');
+    }
+
+    // Toggle dark mode
+    darkModeToggle.addEventListener('click', () => {
+        const isDarkMode = document.documentElement.getAttribute('data-theme') === 'dark';
+        
+        if (isDarkMode) {
+            document.documentElement.removeAttribute('data-theme');
+            icon.classList.replace('fa-sun', 'fa-moon');
+            localStorage.setItem('darkMode', 'false');
+        } else {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            icon.classList.replace('fa-moon', 'fa-sun');
+            localStorage.setItem('darkMode', 'true');
+        }
+    });
+});

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,33 @@
+function initThemeToggle() {
+    const themeToggle = document.querySelector('.theme-toggle');
+    const icon = themeToggle.querySelector('i');
+    const html = document.documentElement;
+    
+    // Check saved theme preference
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    html.setAttribute('data-theme', savedTheme);
+    updateThemeIcon(icon, savedTheme);
+    
+    // Toggle theme on click
+    themeToggle.addEventListener('click', () => {
+        const currentTheme = html.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        
+        html.setAttribute('data-theme', newTheme);
+        localStorage.setItem('theme', newTheme);
+        updateThemeIcon(icon, newTheme);
+    });
+}
+
+function updateThemeIcon(icon, theme) {
+    if (theme === 'dark') {
+        icon.classList.remove('fa-moon');
+        icon.classList.add('fa-sun');
+    } else {
+        icon.classList.remove('fa-sun');
+        icon.classList.add('fa-moon');
+    }
+}
+
+// Initialize theme toggle when DOM is loaded
+document.addEventListener('DOMContentLoaded', initThemeToggle);

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,13 @@
     <!-- Custom CSS -->
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/animations.css">
+    <link rel="stylesheet" href="/static/css/theme.css">
+    
+    <!-- Remove these lines -->
+    <!-- Add in the head section -->
+    <!-- <link rel="stylesheet" href="/static/css/dark-mode.css"> -->
+    <!-- Add before closing body tag -->
+    <!-- <script src="/static/js/dark-mode.js"></script> -->
 </head>
 <body>
     <div class="page-wrapper">
@@ -149,6 +156,7 @@
     <!-- Custom JavaScript -->
     <script src="/static/js/main.js"></script>
     <script src="/static/js/animations.js"></script>
+    <script src="/static/js/theme.js"></script>
     
     <!-- Initialize Scripts -->
     <script>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -16,6 +16,11 @@
                 <li><a href="/team">Team</a></li>
                 <li><a href="/blog">Blog</a></li>
                 <li><a href="/contact">Contact</a></li>
+                <li>
+                    <button id="darkModeToggle" class="dark-mode-toggle">
+                        <i class="fas fa-moon"></i>
+                    </button>
+                </li>
             </ul>
         </nav>
     </div>


### PR DESCRIPTION
Introduce dark mode functionality with a toggle button in the header. Add theme.css and theme.js for managing theme styles and preferences. Include dark-mode.css and dark-mode.js for dark mode specific styles and functionality. Update base.html to include theme-related assets and remove redundant dark mode references.